### PR TITLE
Updated "dependencies" to "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "url": "https://github.com/Wildhoney/ConcaveHull/issues"
   },
   "homepage": "https://github.com/Wildhoney/ConcaveHull",
-  "dependencies": {
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
     "bower": "^1.3.9",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
Dependencies what were listed in package.json were actually
development dependenices so moved them under "devDependencies".
Also added "files" section because only `dist` directory is
needed.

For us it were important to be development dependencies because
we run `nsp check` for our project and we got few security vulnerability alerts from this project.
